### PR TITLE
feat: add optional resources field to ResticOptions

### DIFF
--- a/containers.k
+++ b/containers.k
@@ -24,6 +24,18 @@ _restic_container = corev1.Container {
     name: "restic"
     image: _input.restic.image
     envFrom: [_backupEnvSource]
+    if _input.restic.resources?.requests?.memory:
+        env: [{
+            name: "GOMEMLIMIT"
+            valueFrom: {
+                resourceFieldRef: {
+                    resource: "requests.memory"
+                    divisor: "1"
+                }
+            }
+        }]
+    if _input.restic.resources:
+        resources: _input.restic.resources
     volumeMounts: _restic_volume_mounts
 }
 

--- a/input.k
+++ b/input.k
@@ -90,3 +90,6 @@ schema ResticOptions:
     # This can be handy for safety
     forget_dry_run: bool = False
     extra_forget_args: [str] = []
+    # Resource requests/limits for restic containers. No limits are set by default.
+    # When requests.memory is set, GOMEMLIMIT is automatically set to match via the Downward API.
+    resources?: corev1.ResourceRequirements

--- a/kcl.mod
+++ b/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-restic-cronjob"
 edition = "v0.10.0"
-version = "0.0.3"
+version = "0.0.4"
 
 [dependencies]
 k8s = "1.31.1"


### PR DESCRIPTION
## Summary

- Adds `resources?: corev1.ResourceRequirements` to `ResticOptions` schema in `input.k`
- When `resources` is set, it is applied to all restic step containers (check, backup, forget, prune)
- When `requests.memory` is set, `GOMEMLIMIT` is automatically wired via the Downward API (`divisor: "1"`, so GOMEMLIMIT matches requests.memory in bytes)
- No default value — jobs without `resources` in their `input.yaml` are unchanged

## Usage

```yaml
restic:
  resources:
    requests:
      cpu: "500m"
      memory: "512Mi"
```

## Test plan

- [x] `kcl run . -Dinput=samples/minimal/input.yaml` produces identical output to existing `samples/minimal/output.yaml`
- [x] Running with `resources` set produces `resources` + `GOMEMLIMIT` env var on all restic containers
- [x] Running without `resources` produces no change to container spec