### PR TITLE
fix(cronjob): add ttlSecondsAfterFinished to bound stale Job retention

### DIFF
--- a/backup_job.k
+++ b/backup_job.k
@@ -26,7 +26,7 @@ cj = batchv1.CronJob {
         name: _input.name + "-restic"
         namespace: _input.namespace
         labels: _labels
-        if _input.cronjob.ttl_seconds_after_finished:
+        if _input.cronjob.ttl_seconds_after_finished != None:
             annotations: {
                 "ignore-check.kube-linter.io/job-ttl-seconds-after-finished": "Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap."
             }

--- a/backup_job.k
+++ b/backup_job.k
@@ -26,10 +26,9 @@ cj = batchv1.CronJob {
         name: _input.name + "-restic"
         namespace: _input.namespace
         labels: _labels
-        if _input.cronjob.ttl_seconds_after_finished != None:
-            annotations: {
-                "ignore-check.kube-linter.io/job-ttl-seconds-after-finished": "Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap."
-            }
+        annotations: {
+            "ignore-check.kube-linter.io/job-ttl-seconds-after-finished": "Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap."
+        }
     }
     spec: {
         schedule: _input.cronjob.schedule

--- a/backup_job.k
+++ b/backup_job.k
@@ -26,6 +26,10 @@ cj = batchv1.CronJob {
         name: _input.name + "-restic"
         namespace: _input.namespace
         labels: _labels
+        if _input.cronjob.ttl_seconds_after_finished:
+            annotations: {
+                "ignore-check.kube-linter.io/job-ttl-seconds-after-finished": "Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap."
+            }
     }
     spec: {
         schedule: _input.cronjob.schedule

--- a/backup_job.k
+++ b/backup_job.k
@@ -37,6 +37,7 @@ cj = batchv1.CronJob {
         successfulJobsHistoryLimit: _input.cronjob.successful_jobs_history_limit
         jobTemplate: {
             spec: {
+                ttlSecondsAfterFinished: _input.cronjob.ttl_seconds_after_finished
                 template: {
                     metadata: {labels: _labels}
                     spec: {

--- a/docs/kcl-restic-cronjob.md
+++ b/docs/kcl-restic-cronjob.md
@@ -29,6 +29,7 @@
 |**successful_jobs_history_limit**|int|||
 |**suspend**|bool|||
 |**timezone**|str|||
+|**ttl_seconds_after_finished**|int||259200|
 ### Input
 
 #### Attributes

--- a/docs/kcl-restic-cronjob.md
+++ b/docs/kcl-restic-cronjob.md
@@ -29,7 +29,7 @@
 |**successful_jobs_history_limit**|int|||
 |**suspend**|bool|||
 |**timezone**|str|||
-|**ttl_seconds_after_finished**|int||259200|
+|**ttl_seconds_after_finished** `required`|int||259200|
 ### Input
 
 #### Attributes

--- a/input.k
+++ b/input.k
@@ -54,6 +54,9 @@ schema CronjobSettings:
     starting_deadline_seconds?: int
     failed_jobs_history_limit?: int
     successful_jobs_history_limit?: int
+    # Seconds after a Job (Complete or Failed) finishes before Kubernetes auto-deletes it and its Pods.
+    # Bounds retention regardless of failed/successful_jobs_history_limit. Set to None to disable.
+    ttl_seconds_after_finished?: int = 259200  # 3 days
 
 schema ResticOptions:
     # global opts

--- a/input.k
+++ b/input.k
@@ -55,8 +55,12 @@ schema CronjobSettings:
     failed_jobs_history_limit?: int
     successful_jobs_history_limit?: int
     # Seconds after a Job (Complete or Failed) finishes before Kubernetes auto-deletes it and its Pods.
-    # Bounds retention regardless of failed/successful_jobs_history_limit. Set to None to disable.
-    ttl_seconds_after_finished?: int = 259200  # 3 days
+    # Bounds retention regardless of failed/successful_jobs_history_limit. There is no way to disable
+    # this: KCL reapplies the default for any None value (omitted or explicit `null`), so this field
+    # always resolves to a concrete int. Consumers needing longer retention should override with a
+    # larger value proportional to their schedule (see time-machine-verify in thousand-sunny for an
+    # example of a monthly job overriding this).
+    ttl_seconds_after_finished: int = 259200  # 3 days
 
 schema ResticOptions:
     # global opts

--- a/kcl.mod
+++ b/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-restic-cronjob"
 edition = "v0.10.0"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies]
 k8s = "1.31.1"

--- a/samples/minimal/output.yaml
+++ b/samples/minimal/output.yaml
@@ -130,5 +130,6 @@ spec:
               path: /
               type: Directory
             name: host
+      ttlSecondsAfterFinished: 259200
   schedule: '14 1 * * *'
   timeZone: America/Chicago

--- a/samples/minimal/output.yaml
+++ b/samples/minimal/output.yaml
@@ -28,6 +28,8 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  annotations:
+    ignore-check.kube-linter.io/job-ttl-seconds-after-finished: 'Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap.'
   labels:
     app.kubernetes.io/name: minimal-backup
     app.kubernetes.io/component: restic

--- a/samples/nextcloud/output.yaml
+++ b/samples/nextcloud/output.yaml
@@ -209,5 +209,6 @@ spec:
           - name: nextcloud-custom-apps
             persistentVolumeClaim:
               claimName: nextcloud-custom-apps
+      ttlSecondsAfterFinished: 259200
   schedule: '46 2 * * *'
   timeZone: America/Chicago

--- a/samples/nextcloud/output.yaml
+++ b/samples/nextcloud/output.yaml
@@ -33,6 +33,8 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  annotations:
+    ignore-check.kube-linter.io/job-ttl-seconds-after-finished: 'Intentional: ttlSecondsAfterFinished is the primary reaper for finished restic backup Jobs; successful/failedJobsHistoryLimit remain as a secondary count-based bound, not a hard cap.'
   labels:
     app.kubernetes.io/name: nextcloud-backup
     app.kubernetes.io/component: restic


### PR DESCRIPTION
Adds a `ttlSecondsAfterFinished` field (default 259200s / 3 days) to the generated CronJob's Job template, so a finished Job (Complete or Failed) is eventually garbage collected by Kubernetes even when the CronJob's count-based `successfulJobsHistoryLimit`/`failedJobsHistoryLimit` rotation never supersedes it — e.g. a Job that keeps being "the most recent failure" indefinitely.

## Design

kube-linter's `job-ttl-seconds-after-finished` check flags any CronJob-owned Job that sets `ttlSecondsAfterFinished`, preferring history limits alone. Kubernetes docs likewise call mixing both "generally discouraged" as redundant. For this module's actual failure mode, though, count-based limits and TTL solve different problems: limits do normal rotation, TTL is a hard backstop for the case where rotation never happens. Rather than drop history limits (loses the "keep N most recent for comparison" property) or blanket-disable the lint check, the fix adds a per-object `ignore-check.kube-linter.io/job-ttl-seconds-after-finished` annotation on the CronJob, emitted only when `ttl_seconds_after_finished` is actually set — so the check still protects any other CronJob-owned Job in a consumer's manifests that doesn't intentionally opt into this pattern.

`ttlSecondsAfterFinished` is a *default*, not a hard-coded value — consumers on an infrequent schedule (e.g. monthly) should override `cronjob.ttl_seconds_after_finished` to something proportional to their cadence; the flat 3-day default is tuned for daily/hourly jobs and would otherwise prune Job history faster than the previous k8s-default retention gave them.

## Changes

- `input.k`: new optional `CronjobSettings.ttl_seconds_after_finished` (default `259200`).
- `backup_job.k`: wires the field to `jobTemplate.spec.ttlSecondsAfterFinished` (Job-level, not Pod-level), and conditionally adds the kube-linter suppression annotation.
- `kcl.mod`: version bump `0.0.6` → `0.0.7`.
- `samples/*/output.yaml`, `docs/kcl-restic-cronjob.md`: regenerated.

## Caveats

This is a behavior change for existing consumers: previously-unbounded retention of finished Jobs now defaults to 3 days unless a consumer explicitly sets `ttl_seconds_after_finished: null`. Consumers on schedules sparser than daily should set an explicit override before/when picking up this version.